### PR TITLE
feat: conditionally hide navbar on landing page based on route meta

### DIFF
--- a/frontend/study-sync-app/src/App.vue
+++ b/frontend/study-sync-app/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app class="no-scroll-container">
-    <Navbar />
+    <Navbar v-if="showNavbar" />
     <v-main>
       <div class="main-content">
         <router-view />
@@ -18,6 +18,11 @@ export default {
   components: {
     Navbar,
     Footer,
+  },
+  computed: {
+    showNavbar() {
+      return !this.$route.meta.hideNavbar;
+    },
   },
 };
 </script>

--- a/frontend/study-sync-app/src/components/LandingPage.vue
+++ b/frontend/study-sync-app/src/components/LandingPage.vue
@@ -291,7 +291,7 @@ export default {
   },
   methods: {
     navigateToApp() {
-      this.$router.push("/register");
+      this.$router.push("/");
     },
   },
 };

--- a/frontend/study-sync-app/src/router/index.js
+++ b/frontend/study-sync-app/src/router/index.js
@@ -20,7 +20,7 @@ const routes = [
   { path: "/register", component: UserRegister },
   { path: "/login", component: UserLogin },
   { path: "/profile", component: UserProfile, meta: { requiresAuth: true } },
-  { path: "/landing", component: LandingPage },
+  { path: "/landing", component: LandingPage, meta: { hideNavbar: true } },
   { path: "/forgot-password", component: ForgotPassword },
   {
     path: "/materials",


### PR DESCRIPTION
This pull request updates the navigation and routing logic for the landing page and registration flow. The main focus is on conditionally displaying the `Navbar` component and improving the user flow from the landing page.

Navigation and UI updates:

* The `Navbar` component in `App.vue` is now conditionally rendered based on a new computed property, so it will be hidden on routes where `meta.hideNavbar` is set [[1]](diffhunk://#diff-5eb924c109a592c1cd79839386f6bea354f2239768875232051d09f28eb57e74L3-R3) [[2]](diffhunk://#diff-5eb924c109a592c1cd79839386f6bea354f2239768875232051d09f28eb57e74R22-R26).
* The `/landing` route now has a `meta` property with `hideNavbar: true`, ensuring the navbar is hidden on the landing page.

Routing and navigation flow:

* The `navigateToApp` method in `LandingPage.vue` now routes users to `/` instead of `/register`, improving the landing-to-app flow.